### PR TITLE
fix: middlewareの認証があるとnextjsの認証を通過するバグ

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.468.0",
-    "next": "latest",
+    "next": "15.2.3",
     "next-themes": "^0.4.3",
     "react": "19.0.0",
     "react-dom": "19.0.0",


### PR DESCRIPTION
github上で警告が出たため。
現状nextjsの認証機能は使っていないので、直さなくても問題ない。